### PR TITLE
Add menu, settings and scrolling world

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,11 @@
     #score { float: left; }
     #status { float: right; }
     #timer { position: absolute; left: 50%; transform: translateX(-50%); }
-    canvas { background: #000; display: block; margin: auto; }
+    #game { background: #000; display: inline-block; }
+    #minimap { background: #000; display: inline-block; margin-left: 10px; }
     h1 { margin-bottom: 5px; }
+    .screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; background: rgba(0,0,0,0.8); }
+    .screen.hidden { display: none; }
   </style>
 </head>
 <body>
@@ -22,7 +25,30 @@
     <span id="timer">[01:30]</span>
     <span id="status">Lives: 05&nbsp;&nbsp;Armor: |||||</span>
   </div>
-  <canvas id="game"></canvas>
+  <div id="wrapper">
+    <canvas id="game"></canvas>
+    <canvas id="minimap" width="150" height="150"></canvas>
+  </div>
+
+  <div id="menu" class="screen">
+    <button id="newGameBtn">Nowa gra</button>
+    <button id="settingsBtn">Ustawienia</button>
+    <button id="creditsBtn">Credits</button>
+  </div>
+  <div id="settingsScreen" class="screen hidden">
+    <h2>Ustawienia</h2>
+    <label>Rozmiar planszy <input id="worldSize" type="number" value="3000"></label><br>
+    <label>Promień statku <input id="shipSize" type="number" value="20"></label><br>
+    <label>Masa statku <input id="shipMass" type="number" value="5"></label><br>
+    <label>Czas rundy (s) <input id="roundTime" type="number" value="90"></label><br>
+    <button id="backBtn">Wróć</button>
+  </div>
+  <div id="creditsScreen" class="screen hidden">
+    <h2>Credits</h2>
+    <p>Stworzone z pomocą OpenAI Codex</p>
+    <button id="creditsBack">Wróć</button>
+  </div>
+
   <script type="module" src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,10 +1,72 @@
 import Game from './game.js';
 
 const canvas = document.getElementById('game');
+const mapCanvas = document.getElementById('minimap');
 const scoreEl = document.getElementById('score');
 const statusEl = document.getElementById('status');
 const timerEl = document.getElementById('timer');
 
-const game = new Game(canvas, scoreEl, statusEl, timerEl);
+const menu = document.getElementById('menu');
+const settingsScreen = document.getElementById('settingsScreen');
+const creditsScreen = document.getElementById('creditsScreen');
+const newGameBtn = document.getElementById('newGameBtn');
+const settingsBtn = document.getElementById('settingsBtn');
+const creditsBtn = document.getElementById('creditsBtn');
+const backBtn = document.getElementById('backBtn');
+const creditsBack = document.getElementById('creditsBack');
 
-game.start();
+const worldSizeInput = document.getElementById('worldSize');
+const shipSizeInput = document.getElementById('shipSize');
+const shipMassInput = document.getElementById('shipMass');
+const roundTimeInput = document.getElementById('roundTime');
+
+let creditsInterval;
+let game;
+
+function hideScreens() {
+  menu.classList.add('hidden');
+  settingsScreen.classList.add('hidden');
+  creditsScreen.classList.add('hidden');
+}
+
+function showMenu() {
+  hideScreens();
+  menu.classList.remove('hidden');
+}
+
+function showSettings() {
+  hideScreens();
+  settingsScreen.classList.remove('hidden');
+}
+
+function showCredits() {
+  hideScreens();
+  creditsScreen.classList.remove('hidden');
+  creditsInterval = setInterval(() => {
+    creditsScreen.style.backgroundColor = `hsl(${Math.floor(Math.random()*360)},50%,20%)`;
+  }, 200);
+}
+
+function hideCredits() {
+  clearInterval(creditsInterval);
+  creditsScreen.style.backgroundColor = 'rgba(0,0,0,0.8)';
+}
+
+function startGame() {
+  hideCredits();
+  hideScreens();
+  Game.DEFAULT_SHIP_RADIUS = parseInt(shipSizeInput.value) || Game.DEFAULT_SHIP_RADIUS;
+  Game.DEFAULT_SHIP_MASS = parseInt(shipMassInput.value) || Game.DEFAULT_SHIP_MASS;
+  Game.ROUND_TIME = parseInt(roundTimeInput.value) || Game.ROUND_TIME;
+  const settings = { worldSize: parseInt(worldSizeInput.value) || Game.WORLD_SIZE };
+  game = new Game(canvas, mapCanvas, scoreEl, statusEl, timerEl, settings);
+  game.start(showMenu);
+}
+
+newGameBtn.onclick = startGame;
+settingsBtn.onclick = showSettings;
+creditsBtn.onclick = showCredits;
+backBtn.onclick = showMenu;
+creditsBack.onclick = () => { hideCredits(); showMenu(); };
+
+showMenu();


### PR DESCRIPTION
## Summary
- add main menu with settings and credits
- support configurable world size and ship parameters
- implement scrolling world with minimap and star background

## Testing
- `node -c main.js`

------
https://chatgpt.com/codex/tasks/task_e_684a3120f6ec8320bb68c4e148acf3bf