### PR TITLE
Fix minimap variable redeclaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Aktualna wersja gry: **0.0.2**
 - Kompletny refaktor kodu: cała logika została przeniesiona do klasy `Game` w pliku `game.js` i uruchamiana jest z modułu `main.js`.
 - Dodano dokumentację w postaci komentarzy opisujących działanie poszczególnych metod i stałych.
 - Poprawiono strukturę projektu tak, aby łatwiej było rozwijać go w przyszłości.
+- Naprawiono błąd uniemożliwiający uruchomienie gry w przeglądarce (podwójna
+  deklaracja zmiennych w funkcji rysującej minimapę).
 
 ## Możliwości gry i przebieg rozgrywki
 - Sterowanie statkiem (obrót, przyspieszanie, strzał).

--- a/game.js
+++ b/game.js
@@ -404,10 +404,10 @@ export default class Game {
     mctx.strokeRect(0, 0, mw, mh);
     const viewW = this.canvas.width / this.worldWidth * mw;
     const viewH = this.canvas.height / this.worldHeight * mh;
-    const vx = this.viewportX / this.worldWidth * mw;
-    const vy = this.viewportY / this.worldHeight * mh;
+    const viewX = this.viewportX / this.worldWidth * mw;
+    const viewY = this.viewportY / this.worldHeight * mh;
     mctx.strokeStyle = '#fff';
-    mctx.strokeRect(vx, vy, viewW, viewH);
+    mctx.strokeRect(viewX, viewY, viewW, viewH);
     mctx.fillStyle = '#fff';
     this.asteroids.forEach(a => {
       const x = (a.x / this.worldWidth) * mw;


### PR DESCRIPTION
## Summary
- fix duplicate variable names in `drawMinimap`
- update README with bug fix note

## Testing
- `node --check game.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_684a8d733a608320855534ecf87360c9