### PR TITLE
Fix menu warp effect and adjust gravity

### DIFF
--- a/game.js
+++ b/game.js
@@ -1030,7 +1030,7 @@ Game.MAX_INITIAL_ASTEROIDS = 100;
 Game.MAX_ASTEROIDS = 100;
 Game.MAX_SPEED = 6;
 Game.BULLET_MASS = 0.5;
-Game.GRAVITY = 5;
+Game.GRAVITY = 3;
 Game.MAX_PLANETS = 3;
 Game.PALETTE = ['#fff', '#0ff', '#f0f', '#ff0', '#0f0', '#f00', '#00f', '#f80'];
 

--- a/index.html
+++ b/index.html
@@ -17,8 +17,9 @@
     button { font-family: 'Doto', sans-serif; font-size: 48px; margin: 10px; padding: 10px 20px; }
     #footer { margin-top: 10px; font-size: 14px; color: #888; font-weight: bold; }
     .screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; background: rgba(0,0,0,0.8); }
-    #menu { background: #000; overflow: hidden; }
-    #menuStars { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
+    #menu { position: relative; background: rgba(0,0,0,0.8); overflow: hidden; }
+    #menuStars { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0; }
+    #menu button { position: relative; z-index: 1; }
     .screen.hidden { display: none; }
   </style>
 </head>

--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ function renderStars() {
   ctx.fillRect(0, 0, w, h);
   ctx.strokeStyle = '#fff';
   for (const s of starField) {
-    s.z -= 20;
+    s.z -= 10;
     if (s.z <= 0) {
       s.x = (Math.random() - 0.5) * w;
       s.y = (Math.random() - 0.5) * h;


### PR DESCRIPTION
## Summary
- ensure menu starfield canvas is properly layered
- slightly slower warp speed for menu star animation
- tweak gravity to keep orbits stable

## Testing
- `node --check main.js`
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_684aa0c94bc08320ae93b1acad6ea365