### PR TITLE
Improve menu and gravity

### DIFF
--- a/game.js
+++ b/game.js
@@ -484,7 +484,7 @@ class Game {
     let vx = this.ship.thrust.x;
     let vy = this.ship.thrust.y;
     mctx.moveTo((tx / this.worldWidth) * mw, (ty / this.worldHeight) * mh);
-    for (let i = 0; i < 40; i++) {
+    for (let i = 0; i < 120; i++) {
       this.planets.forEach(pl => {
         const dx = pl.x - tx;
         const dy = pl.y - ty;
@@ -584,6 +584,20 @@ class Game {
           this.ship.thrust.y += (dy / dist) * a * dt;
         }
       });
+      this.asteroids.forEach(a => {
+        const dx = a.x - this.ship.x;
+        const dy = a.y - this.ship.y;
+        const distSq = dx * dx + dy * dy;
+        if (distSq > 1) {
+          const dist = Math.sqrt(distSq);
+          const accelShip = Game.GRAVITY * a.mass / distSq;
+          const accelAst = Game.GRAVITY * this.ship.mass / distSq;
+          this.ship.thrust.x += (dx / dist) * accelShip * dt;
+          this.ship.thrust.y += (dy / dist) * accelShip * dt;
+          a.dx -= (dx / dist) * accelAst * dt;
+          a.dy -= (dy / dist) * accelAst * dt;
+        }
+      });
       this.ship.x = (this.ship.x + this.ship.thrust.x + this.worldWidth) % this.worldWidth;
       this.ship.y = (this.ship.y + this.ship.thrust.y + this.worldHeight) % this.worldHeight;
       if (this.keys[Game.KEY_SPACE] && this.ship.canShoot) {
@@ -675,6 +689,25 @@ class Game {
         }
       });
     });
+
+    for (let i = 0; i < this.asteroids.length; i++) {
+      const a = this.asteroids[i];
+      for (let j = i + 1; j < this.asteroids.length; j++) {
+        const b = this.asteroids[j];
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        const distSq = dx * dx + dy * dy;
+        if (distSq > 1) {
+          const dist = Math.sqrt(distSq);
+          const accelA = Game.GRAVITY * b.mass / distSq;
+          const accelB = Game.GRAVITY * a.mass / distSq;
+          a.dx += (dx / dist) * accelA * dt;
+          a.dy += (dy / dist) * accelA * dt;
+          b.dx -= (dx / dist) * accelB * dt;
+          b.dy -= (dy / dist) * accelB * dt;
+        }
+      }
+    }
 
     for (let i = 0; i < this.asteroids.length; i++) {
       const a = this.asteroids[i];

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     h1 { margin-bottom: 5px; font-size: 48px; }
     button { font-family: 'Doto', sans-serif; font-size: 48px; margin: 10px; padding: 10px 20px; }
     #footer { margin-top: 10px; font-size: 14px; color: #888; font-weight: bold; }
-    .screen { position: absolute; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; background: rgba(0,0,0,0.8); }
+    .screen { position: fixed; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; background: rgba(0,0,0,0.8); z-index: 10; }
     #menu { position: relative; background: rgba(0,0,0,0.8); overflow: hidden; }
     #menuStars { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0; }
     #menu button { position: relative; z-index: 1; }

--- a/main.js
+++ b/main.js
@@ -71,11 +71,11 @@ function initStarField() {
   menuStars.width = window.innerWidth;
   menuStars.height = window.innerHeight;
   starField = [];
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 200; i++) {
     starField.push({
-      x: (Math.random() - 0.5) * menuStars.width,
-      y: (Math.random() - 0.5) * menuStars.height,
-      z: Math.random() * menuStars.width
+      x: Math.random() * menuStars.width,
+      y: Math.random() * menuStars.height,
+      phase: Math.random() * Math.PI * 2
     });
   }
 }
@@ -86,28 +86,14 @@ function renderStars() {
   const h = menuStars.height;
   ctx.fillStyle = '#000';
   ctx.fillRect(0, 0, w, h);
-  ctx.strokeStyle = '#fff';
+  const t = performance.now() / 1000;
+  ctx.fillStyle = '#fff';
   for (const s of starField) {
-    s.z -= 10;
-    if (s.z <= 0) {
-      s.x = (Math.random() - 0.5) * w;
-      s.y = (Math.random() - 0.5) * h;
-      s.z = w;
-      s.px = s.x;
-      s.py = s.y;
-    }
-    const k = 128 / s.z;
-    const x = s.x * k + w / 2;
-    const y = s.y * k + h / 2;
-    const px = (s.px ?? s.x) * k + w / 2;
-    const py = (s.py ?? s.y) * k + h / 2;
-    ctx.beginPath();
-    ctx.moveTo(px, py);
-    ctx.lineTo(x, y);
-    ctx.stroke();
-    s.px = s.x;
-    s.py = s.y;
+    const a = 0.5 + 0.5 * Math.sin(t + s.phase);
+    ctx.globalAlpha = a;
+    ctx.fillRect(s.x, s.y, 2, 2);
   }
+  ctx.globalAlpha = 1;
   if (!menu.classList.contains('hidden')) starAnim = requestAnimationFrame(renderStars);
 }
 


### PR DESCRIPTION
## Summary
- fix menu overlay by making `.screen` fixed and high z-index
- remove warp effect from menu stars and replace with twinkling field
- extend trajectory preview on minimap
- add gravitational attraction between ship and asteroids and among asteroids

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684aa33038b883209d711e5be0820d1e