### PR TITLE
Gameplay improvements and UI fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     h1 { margin-bottom: 5px; font-size: 48px; }
     button { font-family: 'Doto', sans-serif; font-size: 48px; margin: 10px; padding: 10px 20px; }
     #footer { margin-top: 10px; font-size: 14px; color: #888; font-weight: bold; }
-    .screen { position: fixed; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; background: rgba(0,0,0,0.8); z-index: 10; }
+    .screen { position: fixed; top: 0; left: 0; width: 100%; height: 100%; display: flex; flex-direction: column; justify-content: center; align-items: center; background: #000; z-index: 100; }
     #menu { position: relative; background: rgba(0,0,0,0.8); overflow: hidden; }
     #menuStars { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: 0; }
     #menu button { position: relative; z-index: 1; }
@@ -30,7 +30,7 @@
     <div id="sidebar">
       <div id="topbar">
         <span id="score">Score: 00000</span>
-        <span id="timer">[02:30]</span>
+        <span id="timer">Timer: [02:30]</span>
         <span id="lives">Lives: 05</span>
         <span id="armor">Armor: |||||</span>
       </div>

--- a/main.js
+++ b/main.js
@@ -100,6 +100,13 @@ function renderStars() {
 let creditsInterval;
 let game;
 
+window.addEventListener('keydown', e => {
+  if (e.key === 'Escape' && game && game.running) {
+    game.running = false;
+    showMenu();
+  }
+});
+
 function hideScreens() {
   cancelAnimationFrame(starAnim);
   menu.classList.add('hidden');


### PR DESCRIPTION
## Summary
- overlay screens always obscure gameplay
- adjust UI: timer label, lives color, minimap colors
- add ESC handler to stop the game and return to menu
- enhance gravity with range-limited attraction and stronger planets
- ship can flip 180° with Enter key
- pickups spawn more often and new `T` pickup extends timer

## Testing
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_684aaa9d67208320a7d791827d46a371