### PR TITLE
Implement shield pickup and enemy counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         <span id="timer">Timer: [02:30]</span>
         <span id="lives">Lives: |||||</span>
         <span id="armor">Armor: |||||</span>
+        <span id="enemies">Enemies: 0</span>
       </div>
       <canvas id="minimap" width="150" height="150"></canvas>
     </div>

--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ const scoreEl = document.getElementById('score');
 const livesEl = document.getElementById('lives');
 const armorEl = document.getElementById('armor');
 const timerEl = document.getElementById('timer');
+const enemiesEl = document.getElementById('enemies');
 
 const menu = document.getElementById('menu');
 const settingsScreen = document.getElementById('settingsScreen');
@@ -81,6 +82,7 @@ function playNoise(duration) {
   src.start();
   src.stop(audioCtx.currentTime + duration);
 }
+window.playNoise = playNoise;
 
 window.playSound = function(type, x, y) {
   if (!game) return;
@@ -236,7 +238,7 @@ async function startGame() {
     minEnemies: parseInt(cfg.minEnemies) || Game.MIN_ENEMIES,
     maxEnemies: parseInt(cfg.maxEnemies) || Game.MAX_ENEMIES
   };
-  game = new Game(canvas, mapCanvas, scoreEl, livesEl, armorEl, timerEl, settings);
+  game = new Game(canvas, mapCanvas, scoreEl, livesEl, armorEl, timerEl, enemiesEl, settings);
   game.paused = false;
   game.start(() => { game.paused = true; showMenu(); });
 }


### PR DESCRIPTION
## Summary
- add enemies counter to UI and Game class
- replace S pickup with temporary shield effect
- show gravity warning on minimap
- update main game logic for shielded collisions and bouncing off planets

## Testing
- `node -c main.js`
- `node -c game.js`


------
https://chatgpt.com/codex/tasks/task_e_684acac04be88320a450326cb557961f