### PR TITLE
Improve mobile controls

### DIFF
--- a/game.js
+++ b/game.js
@@ -737,6 +737,11 @@ class Game {
       this.nearGravityTrap = this.gravityAccel > Game.SHIP_ACCEL * Game.GRAVITY_WARNING_RATIO;
       this.ship.x = (this.ship.x + this.ship.thrust.x + this.worldWidth) % this.worldWidth;
       this.ship.y = (this.ship.y + this.ship.thrust.y + this.worldHeight) % this.worldHeight;
+      if (!this.keys[Game.KEY_UP] && !this.keys[Game.KEY_DOWN] &&
+          !this.keys[Game.KEY_Q] && !this.keys[Game.KEY_E]) {
+        this.ship.thrust.x *= Game.SHIP_DRAG;
+        this.ship.thrust.y *= Game.SHIP_DRAG;
+      }
       if (this.keys[Game.KEY_SPACE] && this.ship.canShoot) {
         const laser = this.laserTimer > 0;
         this.bullets.push({
@@ -1338,6 +1343,7 @@ class Game {
     this.lastTime = timestamp;
     if (!this.paused) this.update(dt);
     this.draw();
+    if (window.updateJoystickIndicator) window.updateJoystickIndicator();
     if (this.running) requestAnimationFrame(t => this.loop(t));
   }
 
@@ -1382,6 +1388,7 @@ Game.GRAVITY_MULT = 0.5;
 Game.PLANET_GRAVITY_MULT = 8;
 Game.GRAVITY_RANGE_FACTOR = 10.5;
 Game.SHIP_ACCEL = 0.035;
+Game.SHIP_DRAG = 0.98;
 Game.GRAVITY_WARNING_RATIO = 0.8;
 Game.MAX_PLANETS = 3;
 Game.MIN_ENEMIES = 3;

--- a/index.html
+++ b/index.html
@@ -28,9 +28,32 @@
     .screen.hidden { display: none; }
     #mobileControls.hidden { display: none; }
     #mobileControls { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 200; pointer-events: auto; }
-    #joystick { position: absolute; width: 80px; height: 80px; border-radius: 50%; background: rgba(255,255,255,0.1); left: 20px; bottom: 20px; pointer-events: none; transition: opacity 0.1s; }
-    #joystick.active { background: rgba(255,255,255,0.3); }
-    #stick { position: absolute; left: 50%; top: 50%; width: 40px; height: 40px; margin-left: -20px; margin-top: -20px; border-radius: 50%; background: rgba(255,255,255,0.3); pointer-events: none; }
+    #joystick {
+      position: absolute;
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.05);
+      left: 50%;
+      top: 50%;
+      margin-left: -40px;
+      margin-top: -40px;
+      pointer-events: none;
+      transition: opacity 0.1s;
+    }
+    #joystick.active { background: rgba(255,255,255,0.2); }
+    #stick {
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 40px;
+      height: 40px;
+      margin-left: -20px;
+      margin-top: -20px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.2);
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- center the mobile joystick and make it more transparent
- hide mobile controls in menus so menu buttons work
- ensure default settings JSON closes properly
- let joystick ball move freely and show current velocity
- add ship drag and expose joystick updates from game loop

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_684b5e13081883209de328863f981a94