### PR TITLE
Improve mobile ship controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Gra to prosta wariacja na temat klasycznych **Asteroids** napisana w HTML5 i JavaScripcie. Sterujemy małym statkiem kosmicznym i staramy się przetrwać jak najdłużej w polu asteroid. Projekt ma charakter demonstracyjny i służy jako baza do dalszych eksperymentów.
 
-Aktualna wersja gry: **0.0.9**
+Aktualna wersja gry: **0.0.10**
 
 ## Co to jest za gra
 - Strzelanka zręcznościowa 2D z widokiem z góry.
@@ -11,8 +11,11 @@ Aktualna wersja gry: **0.0.9**
 - Celem jest uzyskanie jak najwyższego wyniku zanim skończy się czas lub utracimy wszystkie życia.
 
 ## Latest changes
-- Zaktualizowano do wersji **0.0.9**.
+- Zaktualizowano do wersji **0.0.10**.
 - Dodano animowane obracanie statku przy wyrównywaniu kierunku lotu.
+- Usprawniono sterowanie na urządzeniach mobilnych: tapnięcie obraca i strzela w
+  wybranym kierunku, a wirtualny joystick wskazuje aktualny ruch statku.
+- Pole gry posiada teraz 10&nbsp;px margines wokół krawędzi okna.
 - Zoptymalizowano viewport tak, aby w większych oknach widać było więcej planszy.
 - Zmieniono dźwięk bonusu na dłuższy motyw "tuturututu".
 - Kompletny refaktor kodu: cała logika została przeniesiona do klasy `Game` w pliku `game.js` i uruchamiana jest z modułu `main.js`.

--- a/game.js
+++ b/game.js
@@ -105,8 +105,9 @@ class Game {
 
   /** Resize canvas to window size */
   resizeCanvas() {
-    this.canvas.width = window.innerWidth;
-    this.canvas.height = window.innerHeight;
+    const margin = 20;
+    this.canvas.width = window.innerWidth - margin;
+    this.canvas.height = window.innerHeight - margin;
     this.mapCanvas.width = 150;
     this.mapCanvas.height = 150;
   }
@@ -348,6 +349,15 @@ class Game {
       this.rotateTarget = this.rotateStart + diff;
       this.rotateAnim = this.rotateDuration;
     }
+  }
+
+  /** Rotate ship smoothly towards specified angle */
+  rotateTo(angle) {
+    this.rotateStart = this.ship.angle;
+    this.rotateTarget = angle;
+    let diff = ((this.rotateTarget - this.rotateStart + Math.PI) % (Math.PI * 2)) - Math.PI;
+    this.rotateTarget = this.rotateStart + diff;
+    this.rotateAnim = this.rotateDuration;
   }
 
   /** Spawn lines for asteroid explosion */

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Doto:wght@100..900&display=swap');
     body { margin: 0; background: #222; color: #fff; font-family: 'Doto', sans-serif; text-align: center; overflow: hidden; }
-    #wrapper { position: relative; width: 100vw; height: 100vh; }
+    #wrapper { position: absolute; top: 10px; left: 10px; right: 10px; bottom: 10px; }
     #game { background: #000; display: block; width: 100%; height: 100%; }
     #sidebar { display: flex; flex-direction: column; align-items: flex-start; position: absolute; bottom: 10px; right: 10px; background: rgba(0,0,0,0.5); padding: 10px; border-radius: 8px; }
     #topbar { width: 150px; text-align: left; padding: 4px 0; box-sizing: border-box; }


### PR DESCRIPTION
## Summary
- tweak canvas wrapper to leave a 10px margin around the game
- expose `Game.rotateTo()` for smooth angle changes
- improve virtual joystick limits and orientation indicator
- rotate before firing on mobile tap
- bump version to 0.0.10 and document changes

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check main.js`
- `node --check game.js`

------
https://chatgpt.com/codex/tasks/task_e_684b671dc3a483208a45449cc9f35fbb