### PR TITLE
Improve mobile UX and gravity alert

### DIFF
--- a/game.js
+++ b/game.js
@@ -25,6 +25,8 @@ class Game {
 
     this.worldWidth = settings.worldSize || Game.WORLD_SIZE;
     this.worldHeight = settings.worldSize || Game.WORLD_SIZE;
+    this.zoom = settings.zoom || 1;
+    this.isMobile = settings.isMobile || false;
 
     this.keys = {};
     this.bullets = [];
@@ -106,10 +108,15 @@ class Game {
   /** Resize canvas to window size */
   resizeCanvas() {
     const margin = 20;
-    this.canvas.width = window.innerWidth - margin;
-    this.canvas.height = window.innerHeight - margin;
-    this.mapCanvas.width = 150;
-    this.mapCanvas.height = 150;
+    const dispW = window.innerWidth - margin;
+    const dispH = window.innerHeight - margin;
+    this.canvas.style.width = dispW + 'px';
+    this.canvas.style.height = dispH + 'px';
+    this.canvas.width = Math.floor(dispW / this.zoom);
+    this.canvas.height = Math.floor(dispH / this.zoom);
+    const mapSize = this.isMobile ? 112 : 150;
+    this.mapCanvas.width = mapSize;
+    this.mapCanvas.height = mapSize;
   }
 
   /** Update score/lives display */
@@ -1399,7 +1406,8 @@ Game.PLANET_GRAVITY_MULT = 8;
 Game.GRAVITY_RANGE_FACTOR = 10.5;
 Game.SHIP_ACCEL = 0.035;
 Game.SHIP_DRAG = 0.98;
-Game.GRAVITY_WARNING_RATIO = 0.8;
+// warn about strong gravity sooner
+Game.GRAVITY_WARNING_RATIO = 0.4;
 Game.MAX_PLANETS = 3;
 Game.MIN_ENEMIES = 3;
 Game.MAX_ENEMIES = 10;

--- a/index.html
+++ b/index.html
@@ -54,6 +54,11 @@
       background: rgba(255,255,255,0.2);
       pointer-events: none;
     }
+    body.mobile #topbar,
+    body.mobile #minimap {
+      transform: scale(0.75);
+      transform-origin: bottom right;
+    }
   </style>
 </head>
 <body>

--- a/main.js
+++ b/main.js
@@ -37,7 +37,10 @@ const footerVersion = document.getElementById('footerVersion');
 document.title = GAME_NAME;
 menuTitle.textContent = GAME_NAME;
 footerVersion.textContent = 'Version ' + GAME_VERSION;
-if (isMobile) mobileControls.classList.remove('hidden');
+if (isMobile) {
+  mobileControls.classList.remove('hidden');
+  document.body.classList.add('mobile');
+}
 
 let starAnim;
 let starField = [];
@@ -197,6 +200,8 @@ if (isMobile) {
   let maxRadius = 0;
   let lastTapX = 0, lastTapY = 0;
   let returnAnim = null;
+  let releaseTimeout = null;
+  const HOLD_DELAY = 150;
 
   function updateMaxRadius() {
     maxRadius = Math.min(window.innerWidth, window.innerHeight) / 2 - stickRadius;
@@ -257,6 +262,7 @@ if (isMobile) {
     lastTapX = t.clientX;
     lastTapY = t.clientY;
     longPress = false;
+    if (releaseTimeout) { clearTimeout(releaseTimeout); releaseTimeout = null; }
     if (returnAnim) { cancelAnimationFrame(returnAnim); returnAnim = null; }
     lpTimer = setTimeout(() => {
       longPress = true;
@@ -299,10 +305,13 @@ if (isMobile) {
         }, game.rotateDuration * 1000);
       }
     } else {
-      resetKeys();
       joystick.classList.remove('active');
       touchId = null;
-      startReturn();
+      releaseTimeout = setTimeout(() => {
+        resetKeys();
+        startReturn();
+        releaseTimeout = null;
+      }, HOLD_DELAY);
     }
   });
 }
@@ -418,7 +427,9 @@ async function startGame() {
     maxAsteroids: parseInt(cfg.maxAsteroids) || Game.MAX_INITIAL_ASTEROIDS,
     maxPlanets: parseInt(cfg.maxPlanets) || Game.MAX_PLANETS,
     minEnemies: parseInt(cfg.minEnemies) || Game.MIN_ENEMIES,
-    maxEnemies: parseInt(cfg.maxEnemies) || Game.MAX_ENEMIES
+    maxEnemies: parseInt(cfg.maxEnemies) || Game.MAX_ENEMIES,
+    zoom: isMobile ? 0.8 : 1,
+    isMobile
   };
   game = new Game(canvas, mapCanvas, scoreEl, livesEl, armorEl, timerEl, enemiesEl, settings);
   game.paused = false;

--- a/settings.json
+++ b/settings.json
@@ -16,6 +16,6 @@
   "maxSpeed": 2,
   "bulletMass": 0.5,
   "gravityRangeFactor": 10.5,
-  "gravityWarningRatio": 0.8,
+  "gravityWarningRatio": 0.4,
   "enemyDetection": 600
 }


### PR DESCRIPTION
## Summary
- warn about strong gravity sooner
- keep thrusters active briefly after releasing the joystick
- mark body as mobile and shrink HUD on phones
- support zoomed out view on mobile devices

## Testing
- `node --check main.js`
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_684b6c90bca08320a1c03a0e80c2b31f