### PR TITLE
Enhance mobile controls and minimap

### DIFF
--- a/game.js
+++ b/game.js
@@ -85,7 +85,7 @@ class Game {
     };
     this.enterHeld = false;
     this.rotateAnim = 0;
-    this.rotateDuration = 0.15;
+    this.rotateDuration = Game.DEFAULT_ROTATE_DURATION;
     this.rotateStart = 0;
     this.rotateTarget = 0;
 
@@ -361,7 +361,8 @@ class Game {
   }
 
   /** Rotate ship smoothly towards specified angle */
-  rotateTo(angle) {
+  rotateTo(angle, duration = Game.DEFAULT_ROTATE_DURATION) {
+    this.rotateDuration = duration;
     this.rotateStart = this.ship.angle;
     this.rotateTarget = angle;
     let diff = ((this.rotateTarget - this.rotateStart + Math.PI) % (Math.PI * 2)) - Math.PI;
@@ -597,8 +598,13 @@ class Game {
     if (this.peerShip) {
       const px = (this.peerShip.x / this.worldWidth) * mw;
       const py = (this.peerShip.y / this.worldHeight) * mh;
-      mctx.fillStyle = '#0f0';
-      mctx.fillRect(px - 2, py - 2, 4, 4);
+      mctx.strokeStyle = '#0f0';
+      mctx.beginPath();
+      mctx.moveTo(px - 2, py - 2);
+      mctx.lineTo(px + 2, py + 2);
+      mctx.moveTo(px + 2, py - 2);
+      mctx.lineTo(px - 2, py + 2);
+      mctx.stroke();
     }
 
     this.enemies.forEach(e => {
@@ -1449,6 +1455,8 @@ Game.PLANET_GRAVITY_MULT = 8;
 Game.GRAVITY_RANGE_FACTOR = 10.5;
 Game.SHIP_ACCEL = 0.035;
 Game.SHIP_DRAG = 0.98;
+Game.DEFAULT_ROTATE_DURATION = 0.15;
+Game.FAST_ROTATE_DURATION = 0.05;
 // warn about strong gravity sooner
 Game.GRAVITY_WARNING_RATIO = 0.4;
 Game.MAX_PLANETS = 3;

--- a/main.js
+++ b/main.js
@@ -302,11 +302,6 @@ if (isMobile) {
       if (t.identifier === touchId) {
         dx = t.clientX - (joystick.offsetLeft + joystickRadius);
         dy = t.clientY - (joystick.offsetTop + joystickRadius);
-        const dist = Math.hypot(dx, dy);
-        if (dist > maxRadius) {
-          dx = (dx / dist) * maxRadius;
-          dy = (dy / dist) * maxRadius;
-        }
         stick.style.transform = `translate(${dx}px,${dy}px)`;
         updateKeys();
         break;
@@ -322,12 +317,9 @@ if (isMobile) {
         const wx = game.viewportX + (lastTapX - rect.left);
         const wy = game.viewportY + (lastTapY - rect.top);
         const angle = Math.atan2(wy - game.ship.y, wx - game.ship.x);
-        game.rotateTo(angle);
-        setTimeout(() => {
-          if (!game) return;
-          game.keys[Game.KEY_SPACE] = true;
-          setTimeout(() => { if (game) game.keys[Game.KEY_SPACE] = false; }, 100);
-        }, game.rotateDuration * 1000);
+        game.rotateTo(angle, Game.FAST_ROTATE_DURATION);
+        game.keys[Game.KEY_SPACE] = true;
+        setTimeout(() => { if (game) game.keys[Game.KEY_SPACE] = false; }, 100);
       }
     } else {
       joystick.classList.remove('active');


### PR DESCRIPTION
## Summary
- let joystick drag anywhere
- shoot immediately on tap with fast rotate
- mark second player on minimap with a cross

## Testing
- `node --version`
- `node --check main.js game.js`

------
https://chatgpt.com/codex/tasks/task_e_684c5ffb601c8320bfda380f65bc9f5c