### PR TITLE
Improve feedback for invalid multiplayer links

### DIFF
--- a/main.js
+++ b/main.js
@@ -529,6 +529,7 @@ async function handleSessionLink(url) {
     }
   } catch (e) {
     console.error(e);
+    alert('Failed to load multiplayer session link. Please check that the URL is correct.');
   }
 }
 


### PR DESCRIPTION
## Summary
- show an alert when reading a multiplayer session link fails

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684dac4e5ca08320aa794b5d79072db8