### PR TITLE
Add 3D tilt effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Doto:wght@100..900&display=swap');
     body { margin: 0; background: #222; color: #fff; font-family: 'Doto', sans-serif; text-align: center; overflow: hidden; }
-    #wrapper { position: absolute; top: 10px; left: 10px; right: 10px; bottom: 10px; transition: transform 0.3s ease; }
-    #game { background: #000; display: block; width: 100%; height: 100%; }
+    #wrapper { position: absolute; top: 10px; left: 10px; right: 10px; bottom: 10px; transition: transform 0.3s ease; perspective: 800px; }
+    #game { background: #000; display: block; width: 100%; height: 100%; transform-origin: bottom center; transform: rotateX(30deg); }
     #sidebar { display: flex; flex-direction: column; align-items: flex-start; position: absolute; bottom: 10px; right: 10px; background: rgba(0,0,0,0.5); padding: 10px; border-radius: 8px; }
     #topbar { width: 150px; text-align: left; padding: 4px 0; box-sizing: border-box; }
     #score, #lives, #armor, #timer { display: block; }
@@ -43,7 +43,7 @@
       pointer-events: none;
     }
     #swipeHandle.active { display: block; }
-    #mobileControls { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 200; pointer-events: auto; }
+    #mobileControls { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 200; pointer-events: auto; transform-origin: bottom center; transform: rotateX(30deg); transform-style: preserve-3d; }
     #joystick {
       position: absolute;
       width: 80px;
@@ -56,6 +56,8 @@
       margin-top: -40px;
       pointer-events: none;
       transition: opacity 0.1s;
+      transform-origin: bottom center;
+      transform: rotateX(30deg);
     }
     #joystick.active { background: rgba(255,255,255,0.2); }
     #stick {
@@ -69,6 +71,8 @@
       border-radius: 50%;
       background: rgba(255,255,255,0.2);
       pointer-events: none;
+      transform-origin: bottom center;
+      transform: rotateX(30deg);
     }
     body.mobile #topbar,
     body.mobile #minimap {


### PR DESCRIPTION
## Summary
- add CSS perspective to wrapper
- tilt the game board and mobile joystick with `rotateX(30deg)`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685753843fc88320b0a5f61e80a96acc