### PR TITLE
Fix mobile aiming and joystick orientation

### DIFF
--- a/game.js
+++ b/game.js
@@ -208,6 +208,21 @@ class Game {
     return Math.atan2(iy, ix);
   }
 
+  /** Convert a screen delta in pixels to world delta */
+  screenDeltaToWorld(dx, dy) {
+    const wx = (dx + dy / this.isoScale) / 2;
+    const wy = (dy / this.isoScale - dx) / 2;
+    return { x: wx, y: wy };
+  }
+
+  /** Calculate world angle from screen coordinates */
+  screenAngle(sx, sy) {
+    const dx = sx - this.canvas.width / 2;
+    const dy = sy - this.canvas.height / 2;
+    const v = this.screenDeltaToWorld(dx, dy);
+    return Math.atan2(v.y, v.x);
+  }
+
   shipVertices() {
     const r = this.ship.radius;
     const a = this.ship.angle;

--- a/main.js
+++ b/main.js
@@ -283,7 +283,10 @@ if (isMobile) {
     if (!game) return;
     const thr = 10;
     const dist = Math.hypot(dx, dy);
-    if (dist > 0) game.ship.angle = Math.atan2(dy, dx);
+    if (dist > 0) {
+      const vec = game.screenDeltaToWorld(dx, dy);
+      game.ship.angle = Math.atan2(vec.y, vec.x);
+    }
     game.keys[Game.KEY_UP] = dist > thr;
   }
 
@@ -358,9 +361,9 @@ if (isMobile) {
     if (touchId === null) {
       if (!longPress && game) {
         const rect = canvas.getBoundingClientRect();
-        const wx = game.viewportX + (lastTapX - rect.left);
-        const wy = game.viewportY + (lastTapY - rect.top);
-        const angle = Math.atan2(wy - game.ship.y, wx - game.ship.x);
+        const sx = lastTapX - rect.left;
+        const sy = lastTapY - rect.top;
+        const angle = game.screenAngle(sx, sy);
         game.rotateTo(angle, 0);
         game.fireBullet(angle);
       }
@@ -393,9 +396,9 @@ window.addEventListener('keydown', e => {
 canvas.addEventListener('click', e => {
   if (!game) return;
   const rect = canvas.getBoundingClientRect();
-  const wx = game.viewportX + (e.clientX - rect.left);
-  const wy = game.viewportY + (e.clientY - rect.top);
-  const angle = Math.atan2(wy - game.ship.y, wx - game.ship.x);
+  const sx = e.clientX - rect.left;
+  const sy = e.clientY - rect.top;
+  const angle = game.screenAngle(sx, sy);
   game.rotateTo(angle, 0);
   game.fireBullet(angle);
 });


### PR DESCRIPTION
## Summary
- map touch and click coordinates through inverse isometric transform
- use new helper from joystick movement

## Testing
- `node -c main.js`
- `node -c game.js`


------
https://chatgpt.com/codex/tasks/task_e_6859782348388320bfae4281e34761a8